### PR TITLE
added AllPlayableAi class

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,8 @@ Loadouts are written inside classes. There are a couple of generic classes for y
 1. all units, directly in class Loadouts
     1.1 AllUnits
     1.2 AllAi
-    1.3 AllPlayers
+    1.3 AllPlayableAi
+    1.4 AllPlayers
 2. by side, in Loadouts/Side:
     2.1 Side classes ( Blufor, Opfor, Independent and Civilian )
     2.2 Side AI classes ( BluforAi, OpforAi, IndependentAi and CivilianAi )

--- a/functions/init/fn_applyLoadout.sqf
+++ b/functions/init/fn_applyLoadout.sqf
@@ -38,6 +38,11 @@ _getSidePath = {
         _loadoutHierarchy pushBack ([_configPath >> "AllAi"] call A3G_Loadout_fnc_ExtractLoadoutFromConfig);
 	};
 
+  // All playable AI units
+  if (!isPlayer _x && _x in playableUnits && { isClass ( _configPath >> "AllPlayableAi")}) then {
+        _loadoutHierarchy pushBack ([_configPath >> "AllPlayableAi"] call A3G_Loadout_fnc_ExtractLoadoutFromConfig);
+  };
+
 	// All players
 	if( isPlayer _x && { isClass ( _configPath >> "AllPlayers" )}) then {
         _loadoutHierarchy pushBack ([_configPath >> "AllPlayers"] call A3G_Loadout_fnc_ExtractLoadoutFromConfig);


### PR DESCRIPTION
Wenn ich Loadouts über Einheiten-Klassennamen vergebe, aber beim Testen trotzdem das Loadout aller spielbaren Einheiten auf einmal sehen will, brauche ich AllPlayableAi, damit nicht auch alle anderen KI Einheiten mit den gleichen Einheiten-Klassennamen das Loadout bekommen.

So die Überlegung... :)

Kannst ja mal gucken, ob das wirklich schon alles ist, was man dafür braucht.
