### PR TITLE
respawn loadout fix

### DIFF
--- a/functions/init/fn_applyLoadout.sqf
+++ b/functions/init/fn_applyLoadout.sqf
@@ -1,11 +1,12 @@
 private ["_configPath", "_isMissionStart", "_sidePath", "_getSidePath", "_rolePath", "_namePath", "_typePath"];
+params [["_mode", ""]];
 
 _configPath = missionConfigFile >> "Loadouts";
 if (!isNil "GRAD_Loadout_Chosen_Prefix") then {
     _configPath = _configPath >> GRAD_Loadout_Chosen_Prefix;
 };
 
-_isMissionStart = if (typeName (_this select 0) == "STRING") then {if ((_this select 0) == "postInit") then {true} else {false}} else {false};
+_isMissionStart = if (typeName _mode == "STRING") then {if (_mode == "postInit") then {true} else {false}} else {false};
 
 // Make sure that only local player is considered as target on respawn.
 // This is because AI don't respawn, and we especially don't want to have local AI go through an entire loadout loop again, everytime the player respawns that the AI belongs to.

--- a/functions/init/fn_applyLoadout.sqf
+++ b/functions/init/fn_applyLoadout.sqf
@@ -5,7 +5,7 @@ if (!isNil "GRAD_Loadout_Chosen_Prefix") then {
     _configPath = _configPath >> GRAD_Loadout_Chosen_Prefix;
 };
 
-_isMissionStart = if ( !isNil { _this select 0 } && { _this select 0 == "postInit" }) then { true } else { false };
+_isMissionStart = if (typeName (_this select 0) == "STRING") then {if ((_this select 0) == "postInit") then {true} else {false}} else {false};
 
 // Make sure that only local player is considered as target on respawn.
 // This is because AI don't respawn, and we especially don't want to have local AI go through an entire loadout loop again, everytime the player respawns that the AI belongs to.


### PR DESCRIPTION
[Respawn event handler](https://github.com/gruppe-adler/grad-loadout/blob/master/functions/init/fn_assignRespawn.sqf#L3) passes respawned unit to A3G_Loadout_fnc_ApplyLoadout. Generic error occured when object was compared to string.
