### PR TITLE
global faction loadouts and revivers

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,9 +74,9 @@ class Loadouts {
 
 ### GRAD_Loadout_fnc_FactionSetLoadout
 
-You can dynamically alias a faction name:
+You can dynamically alias a faction name and optionally broadcast it over network (parameter 2, bool):
 
-`["BLU_F", "USMC"] call GRAD_Loadout_fnc_FactionSetLoadout;` – thus, you can change loadout presets for your factions. In this example, this would work now:
+`["BLU_F", "USMC", true] call GRAD_Loadout_fnc_FactionSetLoadout;` – thus, you can change loadout presets for your factions. In this example, this would work now:
 
 ```
 class Loadouts {
@@ -92,7 +92,7 @@ class Loadouts {
 
 ### GRAD_Loadout_fnc_AddReviver
 
-dynamically adjust loadout values. This example adds a bit of randomization to Russian helmets:
+dynamically adjust loadout values. This example adds a bit of randomization to Russian helmets and broadcasts the reviver over network (parameter 2, bool):
 
 ```
 [
@@ -103,7 +103,8 @@ dynamically adjust loadout values. This example adds a bit of randomization to R
         };
         _value
     },
-    "headgear"
+    "headgear",
+    true
 ] call GRAD_Loadout_fnc_addReviver;
 ```
 

--- a/functions/general/fn_factionGetLoadout.sqf
+++ b/functions/general/fn_factionGetLoadout.sqf
@@ -3,11 +3,7 @@
 #define COMPONENT loadout
 #include "\x\cba\addons\main\script_macros_mission.hpp"
 
-private _faction = param [0];
+params [["_faction",""]];
 
-private _path = _faction;
-if ([GRAD_Loadout_factionPathMap, _faction] call CBA_fnc_hashHasKey) then {
-    _path = [GRAD_Loadout_factionPathMap, _faction] call CBA_fnc_hashGet;
-};
-
-_path
+// return faction as path if no value exists
+GVAR(factionPathMap) getVariable [_faction,_faction]

--- a/functions/general/fn_factionSetLoadout.sqf
+++ b/functions/general/fn_factionSetLoadout.sqf
@@ -1,6 +1,9 @@
 // usage: ["BLU_T", "BwFleck"] call GRAD_Loadout_FactionSetLoadout;
 
-private _faction = param [0];
-private _loadoutClass = param [1];
+#define PREFIX grad
+#define COMPONENT loadout
+#include "\x\cba\addons\main\script_macros_mission.hpp"
 
-[GRAD_Loadout_factionPathMap, _faction, _loadoutClass] call CBA_fnc_hashSet;
+params [["_faction",""],["_loadoutClass",""],["_global",false]];
+
+GVAR(factionPathMap) setVariable [_faction,_loadoutClass,_global];

--- a/functions/general/fn_initGlobals.sqf
+++ b/functions/general/fn_initGlobals.sqf
@@ -8,5 +8,5 @@ GVAR(Chosen_Prefix) = "";
 
 // note: units get property GRAD_Loadout_applicationCount
 
-GVAR(factionPathMap) = [] call CBA_fnc_hashCreate;
-GVAR(revivers) = [] call CBA_fnc_hashCreate;
+GVAR(factionPathMap) = [true] call CBA_fnc_createNamespace;
+GVAR(revivers) = [true] call CBA_fnc_createNamespace;

--- a/functions/revivers/fn_addReviver.sqf
+++ b/functions/revivers/fn_addReviver.sqf
@@ -3,16 +3,9 @@
 #define COMPONENT loadout
 #include "\x\cba\addons\main\script_macros_mission.hpp"
 
-private _callback = param [0];
-private _propertyName = param [1];
+params [["_callBack",{}],["_propertyName",""],["_global",false]];
 
-private _revivers = GVAR(revivers);
-private _pRevivers = [];
-
-if ([_revivers, _propertyName] call CBA_fnc_hashHasKey) then {
-	_pRevivers = [_revivers, _propertyName] call CBA_fnc_hashGet;
-};
+private _pRevivers = GVAR(revivers) getVariable [_propertyName,[]];
 
 _pRevivers pushBack _callback;
-
-[_revivers, _propertyName, _pRevivers] call CBA_fnc_hashSet;
+GVAR(revivers) setVariable [_propertyName,_pRevivers,_global];

--- a/functions/revivers/fn_getRevivers.sqf
+++ b/functions/revivers/fn_getRevivers.sqf
@@ -3,13 +3,6 @@
 #define COMPONENT loadout
 #include "\x\cba\addons\main\script_macros_mission.hpp"
 
-private _propertyName = param [0];
+params [["_propertyName",""]];
 
-private _revivers = GVAR(revivers);
-private _pRevivers = [];
-
-if ([_revivers, _propertyName] call CBA_fnc_hashHasKey) then {
-	_pRevivers = [_revivers, _propertyName] call CBA_fnc_hashGet;
-};
-
-_pRevivers
+GVAR(revivers) getVariable [_propertyName,[]]

--- a/package.json
+++ b/package.json
@@ -16,5 +16,5 @@
         }
     ],
     "description": "Declarative loadout script for Arma3",
-    "version": "4.7.1"
+    "version": "4.8.0"
 }


### PR DESCRIPTION
Changes:
* changes GVAR(factionPathMap) and GVAR(revivers) from CBA_hashes to CBA_namespaces
*  adds third parameter to FUNC(factionSetLoadout) and FUNC(addReviver), to broadcast changes over network

Advantages:
Easier JIP handling in missions with dynamically set loadouts. Example: CO_Prometheus where loadouts are set by Zeus after mission start.