### PR TITLE
fix 21: dont apply to units where no loadout definition matched

### DIFF
--- a/functions/api/fn_doLoadoutForUnit.sqf
+++ b/functions/api/fn_doLoadoutForUnit.sqf
@@ -15,4 +15,9 @@ TRACE_1("applying loadout from mission config file %1 to %2 ...", _configPath, _
 
 private _loadoutHash = [_unit, _configPath] call FUNC(GetUnitLoadoutFromConfig);
 _loadoutHash = [_loadoutHash, _unit] call FUNC(ApplyRevivers);
-[_loadoutHash, _unit] call FUNC(DoLoadout);
+
+if (([_loadoutHash] call CBA_fnc_hashSize) > 0) then {
+    [_loadoutHash, _unit] call FUNC(DoLoadout);
+} else {
+    TRACE_1("no loadout entries found for %1, skipping unit", _unit);
+};

--- a/functions/general/fn_scheduleLoadout.sqf
+++ b/functions/general/fn_scheduleLoadout.sqf
@@ -4,8 +4,8 @@
 #include "\x\cba\addons\main\script_macros_mission.hpp"
 
 private _getDelay = {
-    _baseDelay = [(missionConfigFile >> "Loadouts"), "baseDelay", 10] call BIS_fnc_returnConfigEntry;
-    _perPlayerDelay = [(missionConfigFile >> "Loadouts"), "perPlayerDelay", 1] call BIS_fnc_returnConfigEntry;
+    private _baseDelay = [(missionConfigFile >> "Loadouts"), "baseDelay", 10] call BIS_fnc_returnConfigEntry;
+    private _perPlayerDelay = [(missionConfigFile >> "Loadouts"), "perPlayerDelay", 1] call BIS_fnc_returnConfigEntry;
 
     _baseDelay + floor(_perPlayerDelay * random (count allPlayers));
 };
@@ -17,7 +17,7 @@ systemChat format ["grad-loadout: waiting %1 s for loadout...", _delay];
 
 [
 	{
-        _msg = "triggering loadout...";
+        private _msg = "triggering loadout...";
 		INFO(_msg);
         systemChat ("grad-loadout: " + _msg);
 		[_this select 0] call FUNC(ApplyLoadout);


### PR DESCRIPTION
dont apply to units where no loadout definition matched – thus, resetLoadout=1 will *not* make units undress unless there is *something* defined for them.

tl;dr: no naked units because of resetLoadout=1

should fix #21 