### PR TITLE
save custom gear

### DIFF
--- a/cfgFunctions.hpp
+++ b/cfgFunctions.hpp
@@ -18,6 +18,7 @@ class GRAD_Loadout {
         class initCustomGear {preInit = 1;};
         class onCustomGearListSelection {};
         class onCustomGearTabButton {};
+        class onCustomGearUnload {};
         class openCustomGearDialog {};
         class setAllowedCategories {};
         class updateCamera {};

--- a/functions/api/fn_doLoadoutForUnit.sqf
+++ b/functions/api/fn_doLoadoutForUnit.sqf
@@ -11,7 +11,7 @@ if (GVAR(Chosen_Prefix) != "") then {
 TRACE_1("applying loadout from mission config file %1 to %2 ...", _configPath, _unit);
 
 private _loadoutHash = [_unit, _configPath] call FUNC(GetUnitLoadoutFromConfig);
-[_loadoutHash] call FUNC(randomizeLoadout);
+[_loadoutHash, _unit] call FUNC(randomizeLoadout);
 _loadoutHash = [_loadoutHash, _unit] call FUNC(ApplyRevivers);
 
 if (([_loadoutHash] call CBA_fnc_hashSize) > 0) then {

--- a/functions/customgear/fn_onCustomGearUnload.sqf
+++ b/functions/customgear/fn_onCustomGearUnload.sqf
@@ -1,0 +1,23 @@
+#include "component.hpp"
+
+params [["_display",displayNull]];
+
+// destroy cam
+GVAR(customGearCam) cameraeffect ["terminate", "back"];
+camDestroy GVAR(customGearCam);
+GVAR(customGearCam) = nil;
+
+// save selected loadout
+private _unit = _display getVariable [QGVAR(unit), objNull];
+private _loadoutOptionsHash = _display getVariable [QGVAR(loadoutOptionsHash), []];
+
+private _savedCustomGearHash = [[], false] call CBA_fnc_hashCreate;
+
+[_loadoutOptionsHash, {
+    private _currentItem = [_unit, _key, true] call FUNC(getCurrentItem);
+    if (_currentItem isEqualType "" && {_currentItem != ""}) then {
+        [_savedCustomGearHash, _key, toLower _currentItem] call CBA_fnc_hashSet;
+    };
+}] call CBA_fnc_hashEachPair;
+
+_unit setVariable [QGVAR(savedCustomGearHash), _savedCustomGearHash, false];

--- a/functions/customgear/fn_openCustomGearDialog.sqf
+++ b/functions/customgear/fn_openCustomGearDialog.sqf
@@ -38,10 +38,6 @@ uiNamespace setVariable [QGVAR(customGearDisplay), _display];
 _display setVariable [QGVAR(loadoutOptionsHash), _loadoutOptionsHash];
 _display setVariable [QGVAR(unit), _unit];
 
-_display displayAddEventHandler ["unload" ,{
-    GVAR(customGearCam) cameraeffect ["terminate", "back"];
-    camDestroy GVAR(customGearCam);
-    GVAR(customGearCam) = nil;
-}];
+_display displayAddEventHandler ["unload", {_this call FUNC(onCustomGearUnload)}];
 
 [_display] call FUNC(createCustomGearDialog);

--- a/functions/general/fn_randomizeLoadout.sqf
+++ b/functions/general/fn_randomizeLoadout.sqf
@@ -1,11 +1,24 @@
 #include "component.hpp"
 
-params [["_loadoutHash", []]];
+params [["_loadoutHash", []], ["_unit", objNull]];
+
+private _savedCustomGearHash = _unit getVariable QGVAR(savedCustomGearHash);
 
 {
     private _value = [_loadoutHash, _x] call CBA_fnc_hashGet;
     if (!isNil "_value" && {_value isEqualType []}) then {
-        if (count _value == 0) then {_value = ""} else {_value = selectRandom _value};
+        if (count _value == 0) then {_value = ""} else {
+            _value = _value apply {toLower _x};
+            if (
+                !isNil "_savedCustomGearHash" &&
+                {[_savedCustomGearHash, _x] call CBA_fnc_hashHasKey} &&
+                {([_savedCustomGearHash, _x] call CBA_fnc_hashGet) in _value}
+            ) then {
+                _value = [_savedCustomGearHash, _x] call CBA_fnc_hashGet;
+            } else {
+                _value = selectRandom _value;
+            };
+        };
         [_loadoutHash, _x, _value] call CBA_fnc_hashSet;
     };
 } forEach [


### PR DESCRIPTION
Saves customGear selections on display unload, so that unit does not have to re-select options when loadout is reapplied (e.g. new round on linear sector defense).